### PR TITLE
Add comparative summary table for AV and CTO results

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,12 @@ class ComparisonResult:
     heritage_total_cto: float
     capital_final_av: float
     capital_final_cto: float
+    patrimoine_total_av: float
+    patrimoine_total_cto: float
+    part_taxable_av: float
+    part_taxable_cto: float
+    impots_payes_av: float
+    impots_payes_cto: float
     difference_totale: float
     relative_difference: Optional[float]
     base_totale: float
@@ -73,6 +79,7 @@ def compute_comparison(inputs: ScenarioInputs) -> Tuple[ComparisonResult, dict]:
     droits_autres_biens_av = calcul_impot_progressif(base_autres_biens_av, bareme_succession)
     heritage_autres_av = inputs.autres_biens_valeur - droits_autres_biens_av
     heritage_total_av = heritage_av + heritage_autres_av
+    patrimoine_total_av = capital_final_av + inputs.autres_biens_valeur
 
     heritage_cto, capital_final_cto = calculer_heritage_cto(
         inputs.capital_initial,
@@ -118,6 +125,12 @@ def compute_comparison(inputs: ScenarioInputs) -> Tuple[ComparisonResult, dict]:
         heritage_total_cto=heritage_total_cto,
         capital_final_av=capital_final_av,
         capital_final_cto=capital_final_cto,
+        patrimoine_total_av=patrimoine_total_av,
+        patrimoine_total_cto=actif_total_cto,
+        part_taxable_av=base_autres_biens_av,
+        part_taxable_cto=base_imposable_totale,
+        impots_payes_av=droits_autres_biens_av,
+        impots_payes_cto=droits_totaux_cto,
         difference_totale=difference_totale,
         relative_difference=relative_difference,
         base_totale=base_totale,

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,8 +68,12 @@
             border-bottom: 1px solid #e0e0e0;
             text-align: left;
         }
-        .results th {
+        .results thead th {
             background-color: #f0f4ff;
+        }
+        .results tbody th {
+            font-weight: 600;
+            width: 40%;
         }
         .alert {
             color: #a94442;
@@ -81,6 +85,16 @@
         .help-text {
             font-size: 0.85rem;
             color: #555;
+        }
+        .difference-card {
+            margin-top: 1.5rem;
+            padding: 1.25rem;
+            border: 1px solid #d6dcf5;
+            border-radius: 6px;
+            background-color: #f8f9ff;
+        }
+        .difference-card h3 {
+            margin-top: 0;
         }
     </style>
 </head>
@@ -149,59 +163,47 @@
             <section class="results full-width">
                 <h2>Résultats</h2>
                 <table>
+                    <thead>
+                        <tr>
+                            <th></th>
+                            <th>Solution AV</th>
+                            <th>Solution CTO</th>
+                        </tr>
+                    </thead>
                     <tbody>
                         <tr>
-                            <th>Capital final Assurance-vie</th>
-                            <td>{{ result.capital_final_av | round(2) }} €</td>
+                            <th scope="row">Patrimoine total</th>
+                            <td>{{ result.patrimoine_total_av | round(2) }} €</td>
+                            <td>{{ result.patrimoine_total_cto | round(2) }} €</td>
                         </tr>
                         <tr>
-                            <th>Héritage net Assurance-vie</th>
-                            <td>{{ result.heritage_av | round(2) }} €</td>
+                            <th scope="row">Part taxable</th>
+                            <td>{{ result.part_taxable_av | round(2) }} €</td>
+                            <td>{{ result.part_taxable_cto | round(2) }} €</td>
                         </tr>
                         <tr>
-                            <th>Autres biens nets (scénario AV)</th>
-                            <td>{{ result.heritage_autres_av | round(2) }} €</td>
+                            <th scope="row">Impôts payés</th>
+                            <td>{{ result.impots_payes_av | round(2) }} €</td>
+                            <td>{{ result.impots_payes_cto | round(2) }} €</td>
                         </tr>
                         <tr>
-                            <th>Héritage net total (AV + autres biens)</th>
+                            <th scope="row">Héritage net de frais</th>
                             <td>{{ result.heritage_total_av | round(2) }} €</td>
-                        </tr>
-                        <tr>
-                            <th>Capital final CTO</th>
-                            <td>{{ result.capital_final_cto | round(2) }} €</td>
-                        </tr>
-                        <tr>
-                            <th>Héritage net CTO</th>
-                            <td>{{ result.heritage_cto | round(2) }} €</td>
-                        </tr>
-                        <tr>
-                            <th>Autres biens nets (scénario CTO)</th>
-                            <td>{{ result.heritage_autres_cto | round(2) }} €</td>
-                        </tr>
-                        <tr>
-                            <th>Héritage net total (CTO + autres biens)</th>
                             <td>{{ result.heritage_total_cto | round(2) }} €</td>
-                        </tr>
-                        <tr>
-                            <th>Différence totale (scénario AV - scénario CTO)</th>
-                            <td>{{ result.difference_totale | round(2) }} €</td>
-                        </tr>
-                        <tr>
-                            <th>Différence relative</th>
-                            <td>
-                                {% if result.relative_difference is not none %}
-                                    {{ (result.relative_difference * 100) | round(2) }} %
-                                {% else %}
-                                    N/A
-                                {% endif %}
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>Base taxable totale (CTO + autres biens)</th>
-                            <td>{{ result.base_totale | round(2) }} €</td>
                         </tr>
                     </tbody>
                 </table>
+                <div class="difference-card">
+                    <h3>Écart entre les solutions</h3>
+                    <p><strong>Différence brute (AV - CTO) :</strong> {{ result.difference_totale | round(2) }} €</p>
+                    <p><strong>Différence relative :</strong>
+                        {% if result.relative_difference is not none %}
+                            {{ (result.relative_difference * 100) | round(2) }} %
+                        {% else %}
+                            N/A
+                        {% endif %}
+                    </p>
+                </div>
                 <h3>Détails des abattements</h3>
                 <ul>
                     <li>Abattement succession unitaire : {{ details.abattement_succession_unitaire | round(2) }} €</li>


### PR DESCRIPTION
## Summary
- reorganized the comparison output into a two-column table contrasting AV and CTO scenarios
- exposed taxable base, taxes paid, and net inheritance metrics for each solution and highlighted the patrimony totals
- added a dedicated card summarizing absolute and relative differences between the scenarios

## Testing
- `python -m compileall app.py templates/index.html`


------
https://chatgpt.com/codex/tasks/task_b_68d3f4e648d88332870b4fd21b955d13